### PR TITLE
fix: filter empty tags on post/put arcade record

### DIFF
--- a/src/features/arcade-record-article/post-arcade-record-action.ts
+++ b/src/features/arcade-record-article/post-arcade-record-action.ts
@@ -136,7 +136,11 @@ export async function postArcadeRecordAction(
       stage: stage!,
       rank,
       comment: comment!,
-      tags: tags?.split(',').map((tag) => tag.trim()) ?? [],
+      tags:
+        tags
+          ?.split(',')
+          .map((tag) => tag.trim())
+          .filter((tag) => tag.length > 0) ?? [],
       note,
       youtube_id: youTubeId,
       thumbnail_url: thumbnailUrl,

--- a/src/features/arcade-record-article/put-arcade-record-action.ts
+++ b/src/features/arcade-record-article/put-arcade-record-action.ts
@@ -156,7 +156,11 @@ export async function putArcadeRecordAction(
       stage: stage!,
       rank,
       comment: comment!,
-      tags: tags?.split(',').map((tag) => tag.trim()) ?? [],
+      tags:
+        tags
+          ?.split(',')
+          .map((tag) => tag.trim())
+          .filter((tag) => tag.length > 0) ?? [],
       note,
       youtube_id: youTubeId,
       thumbnail_url: thumbnailUrl,


### PR DESCRIPTION
- Filtered empty tags when posting/putting an arcade record to prevent weird dot on tag area