### PR TITLE
improvement: add instructions for how to show image modal for arcade record

### DIFF
--- a/src/features/arcade-record-article/arcade-record-thumbnail/index.tsx
+++ b/src/features/arcade-record-article/arcade-record-thumbnail/index.tsx
@@ -12,17 +12,22 @@ export default function ArcadeRecordThumbnail({
   originalImageUrls,
 }: Props) {
   return (
-    <div className="relative w-full sm:w-80 h-80">
-      <Image
-        src={thumbnailUrl}
-        alt="아케이드 기록 썸네일"
-        className="object-contain"
-        fill
-        sizes="20rem"
-      />
-      <ArcadeRecordThumbnailInteractivity
-        originalImageUrls={originalImageUrls}
-      />
-    </div>
+    <figure className="flex flex-col justify-center items-center gap-2">
+      <div className="relative w-full sm:w-80 h-80 bg-black">
+        <Image
+          src={thumbnailUrl}
+          alt="아케이드 기록 썸네일"
+          className="object-contain"
+          fill
+          sizes="20rem"
+        />
+        <ArcadeRecordThumbnailInteractivity
+          originalImageUrls={originalImageUrls}
+        />
+      </div>
+      <figcaption className="text-xs">
+        [ 썸네일을 클릭하여 이미지 보기 ]
+      </figcaption>
+    </figure>
   );
 }


### PR DESCRIPTION
- Added instructions - how to show image modal in arcade record article page.
- Added black background for surface of `ArcadeRecordThumbnail`.