### PR TITLE
fix: expand gap between arcade record thumbnail and summary

### DIFF
--- a/src/features/arcade-record-article/index.tsx
+++ b/src/features/arcade-record-article/index.tsx
@@ -118,7 +118,7 @@ export default function ArcadeRecordArticle({ post }: Props) {
         {renderCreatedAt}
         {renderModifiedAt}
       </div>
-      <section className="w-full flex flex-col sm:flex-row sm:items-center gap-2">
+      <section className="w-full flex flex-col sm:flex-row sm:items-center gap-4">
         <ArcadeRecordThumbnail
           thumbnailUrl={post.thumbnailUrl}
           originalImageUrls={post.imageUrls}


### PR DESCRIPTION
- Fix expand gap into `1rem` between `ArcadeRecordThumbnail` and summary area in `ArcadeRecordArticle` to resolve weirdly narrow gap.