### PR TITLE
fix: prevent unnecessarily page scroll/expand on touch/scroll in (image-viewer) modal

### DIFF
--- a/src/entities/modal/index.tsx
+++ b/src/entities/modal/index.tsx
@@ -35,7 +35,7 @@ export default function Modal() {
   })();
 
   return type !== ModalType.OFF ? (
-    <div className="fixed left-0 top-0 w-screen h-dvh bg-[rgba(0,0,0,0.4)] z-50">
+    <div className="fixed left-0 top-0 w-screen h-dvh bg-[rgba(0,0,0,0.4)] z-50 touch-none">
       {renderModalContent}
       <button
         className="fixed left-0 top-0 w-12 h-12 p-2 m-2"

--- a/src/shared/image-zoom-controller/index.tsx
+++ b/src/shared/image-zoom-controller/index.tsx
@@ -14,6 +14,13 @@ export default function ImageZoomController({ imageUrl, alt }: Props) {
   const [scale, setScale] = useState<number>(1);
 
   useEffect(() => {
+    document.body.style.overflowY = 'hidden';
+    return () => {
+      document.body.style.overflowY = 'auto';
+    };
+  }, []);
+
+  useEffect(() => {
     setRecentTouchDist(-1);
     setPosition([0, 0]);
     setScale(1);
@@ -66,6 +73,9 @@ export default function ImageZoomController({ imageUrl, alt }: Props) {
         document.addEventListener('touchend', handleOnTouchEnd, { once: true });
       }}
       onTouchMove={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+
         if (event.touches.length === 2) {
           const firstPageX = event.touches[0].pageX;
           const firstPageY = event.touches[0].pageY;


### PR DESCRIPTION
- Stopped unnecessarily moving on expand/shrink in modal. (especially `ImageZoomController `)