### PR TITLE
fix: stop youtube-mark animating on hover post list item

### DIFF
--- a/src/entities/post-list-item/index.tsx
+++ b/src/entities/post-list-item/index.tsx
@@ -47,11 +47,11 @@ export default function PostListItem({
   ) : null;
 
   return (
-    <li className="w-full h-80 rounded-2xl overflow-hidden hover:[&_img]:scale-125 [&_img]:transition-all hover:[&_img]:brightness-110">
+    <li className="w-full h-80 rounded-2xl overflow-hidden hover:[&_.post-thumbnail]:scale-125 [&_.post-thumbnail]:transition-all hover:[&_.post-thumbnail]:brightness-110">
       <Link href={href} className="w-full h-full relative flex">
         <div className="absolute left-0 top-0 w-full h-full z-0">
           <Image
-            className="object-cover"
+            className="object-cover post-thumbnail"
             src={thumbnailUrl}
             alt={`${title} ${memo}`}
             fill


### PR DESCRIPTION
- Prevented YouTube mark's animation when hovering `PostListItem`.