### PR TITLE
fix: change review form verification about expectations, first-impressions, positives, negatives, and conclusions

### DIFF
--- a/app/api/reviews/[reviewId]/route.ts
+++ b/app/api/reviews/[reviewId]/route.ts
@@ -47,6 +47,18 @@ export async function PUT(
   const thumbnailUrl = formData.get('thumbnailUrl')?.toString();
   const originalImageUrls = formData.getAll('originalImageUrls') as string[];
 
+  const isExpectationsVerified = expectations.length > 0;
+  const isFirstImpressionsVerified = firstImpressions.length > 0;
+  const isPositivesVerified = positives.length > 0;
+  const isNegativesVerified = negatives.length > 0;
+  const isConclusionsVerified = conclusions.length > 0;
+  const isReviewVerified =
+    isExpectationsVerified ||
+    isFirstImpressionsVerified ||
+    isPositivesVerified ||
+    isNegativesVerified ||
+    isConclusionsVerified;
+
   if (
     !reviewId ||
     !title ||
@@ -55,11 +67,7 @@ export async function PUT(
     !createdBy ||
     !releaseDate ||
     keyFeatures.length === 0 ||
-    expectations.length === 0 ||
-    firstImpressions.length === 0 ||
-    positives.length === 0 ||
-    negatives.length === 0 ||
-    conclusions.length === 0 ||
+    !isReviewVerified ||
     !reviewScore ||
     (!thumbnailUrl && !presentThumbnailUrl) ||
     (presentImageUrls.length === 0 && originalImageUrls.length === 0)

--- a/app/api/reviews/route.ts
+++ b/app/api/reviews/route.ts
@@ -40,6 +40,18 @@ export async function POST(request: Request) {
   const thumbnailUrl = formData.get('thumbnailUrl')?.toString();
   const originalImageUrls = formData.getAll('originalImageUrls') as string[];
 
+  const isExpectationsVerified = expectations.length > 0;
+  const isFirstImpressionsVerified = firstImpressions.length > 0;
+  const isPositivesVerified = positives.length > 0;
+  const isNegativesVerified = negatives.length > 0;
+  const isConclusionsVerified = conclusions.length > 0;
+  const isReviewVerified =
+    isExpectationsVerified ||
+    isFirstImpressionsVerified ||
+    isPositivesVerified ||
+    isNegativesVerified ||
+    isConclusionsVerified;
+
   if (
     !reviewId ||
     !title ||
@@ -48,11 +60,7 @@ export async function POST(request: Request) {
     !createdBy ||
     !releaseDate ||
     keyFeatures.length === 0 ||
-    expectations.length === 0 ||
-    firstImpressions.length === 0 ||
-    positives.length === 0 ||
-    negatives.length === 0 ||
-    conclusions.length === 0 ||
+    !isReviewVerified ||
     !reviewScore ||
     !thumbnailUrl ||
     originalImageUrls.length === 0

--- a/src/entities/unordered-review-theme-list/index.tsx
+++ b/src/entities/unordered-review-theme-list/index.tsx
@@ -1,0 +1,19 @@
+import UnorderedList from '^/src/shared/unordered-list';
+
+interface Props {
+  title: string;
+  items: string[];
+}
+
+export default function UnorderedReviewItemList({ title, items }: Props) {
+  return (
+    <section className="w-full flex flex-col gap-2">
+      <h2 className="text-2xl font-bold">{title}</h2>
+      <UnorderedList>
+        {items.map((item, index) => (
+          <li key={index}>{item}</li>
+        ))}
+      </UnorderedList>
+    </section>
+  );
+}

--- a/src/features/review-article/index.tsx
+++ b/src/features/review-article/index.tsx
@@ -3,10 +3,10 @@ import Image from 'next/image';
 import FilledStarSvgRepoComSvg from '^/public/icons/filled-star-svgrepo-com.svg';
 import StarSvgRepoComSvg from '^/public/icons/star-svgrepo-com.svg';
 import { ReviewPost } from '^/src/entities/types/post';
+import UnorderedReviewItemList from '^/src/entities/unordered-review-theme-list';
 import { CopyLinkButton } from '^/src/shared/share/copy-link';
 import { ShareToTwitterButton } from '^/src/shared/share/share-to-twitter';
 import Tag from '^/src/shared/tag';
-import UnorderedList from '^/src/shared/unordered-list';
 import { parseDateToString } from '^/src/shared/util/parse-date';
 
 import ReviewThumbnail from './review-thumbnail';
@@ -105,50 +105,27 @@ export default function ReviewArticle({ post }: Props) {
         </span>
       </section>
 
-      <section className="w-full flex flex-col gap-2">
-        <h2 className="text-2xl font-bold">기대사항</h2>
-        <UnorderedList>
-          {post.expectations.map((expectation, index) => (
-            <li key={index}>{expectation}</li>
-          ))}
-        </UnorderedList>
-      </section>
+      <UnorderedReviewItemList title="특징" items={post.keyFeatures} />
 
-      <section className="w-full flex flex-col gap-2">
-        <h2 className="text-2xl font-bold">첫인상</h2>
-        <UnorderedList>
-          {post.firstImpressions.map((firstImpression, index) => (
-            <li key={index}>{firstImpression}</li>
-          ))}
-        </UnorderedList>
-      </section>
+      {post.expectations.length > 0 ? (
+        <UnorderedReviewItemList title="기대사항" items={post.expectations} />
+      ) : null}
 
-      <section className="w-full flex flex-col gap-2">
-        <h2 className="text-2xl font-bold">좋았던 점</h2>
-        <UnorderedList>
-          {post.positives.map((positive, index) => (
-            <li key={index}>{positive}</li>
-          ))}
-        </UnorderedList>
-      </section>
+      {post.firstImpressions.length > 0 ? (
+        <UnorderedReviewItemList title="첫인상" items={post.firstImpressions} />
+      ) : null}
 
-      <section className="w-full flex flex-col gap-2">
-        <h2 className="text-2xl font-bold">아쉬웠던 점</h2>
-        <UnorderedList>
-          {post.negatives.map((negative, index) => (
-            <li key={index}>{negative}</li>
-          ))}
-        </UnorderedList>
-      </section>
+      {post.positives.length > 0 ? (
+        <UnorderedReviewItemList title="좋았던 점" items={post.positives} />
+      ) : null}
 
-      <section className="w-full flex flex-col gap-2">
-        <h2 className="text-2xl font-bold">결론</h2>
-        <UnorderedList>
-          {post.conclusions.map((conclusion, index) => (
-            <li key={index}>{conclusion}</li>
-          ))}
-        </UnorderedList>
-      </section>
+      {post.negatives.length > 0 ? (
+        <UnorderedReviewItemList title="아쉬웠던 점" items={post.negatives} />
+      ) : null}
+
+      {post.conclusions.length > 0 ? (
+        <UnorderedReviewItemList title="결론" items={post.conclusions} />
+      ) : null}
 
       <section className="w-full flex flex-col gap-2">
         <h2 className="text-2xl font-bold">태그</h2>

--- a/src/features/review-article/review-form.tsx
+++ b/src/features/review-article/review-form.tsx
@@ -112,11 +112,19 @@ export default function ReviewForm({ post }: Props) {
   const isSubjectTypeVerified = subjectType.length > 0;
   const isCreatedByVerified = createdBy.length > 0;
   const isKeyFeaturesVerified = keyFeatures.length > 0;
+
   const isExpectationsVerified = expectations.length > 0;
   const isFirstImpressionsVerified = firstImpressions.length > 0;
   const isPositivesVerified = positives.length > 0;
   const isNegativesVerified = negatives.length > 0;
   const isConclusionsVerified = conclusions.length > 0;
+  const isReviewVerified =
+    isExpectationsVerified ||
+    isFirstImpressionsVerified ||
+    isPositivesVerified ||
+    isNegativesVerified ||
+    isConclusionsVerified;
+
   const isReviewScoreVerified = reviewScore > 0 && reviewScore <= 5;
 
   const isThumbnailVerified = !!post?.thumbnailUrl || !!localThumbnail;
@@ -129,11 +137,7 @@ export default function ReviewForm({ post }: Props) {
     isSubjectTypeVerified &&
     isCreatedByVerified &&
     isKeyFeaturesVerified &&
-    isExpectationsVerified &&
-    isFirstImpressionsVerified &&
-    isPositivesVerified &&
-    isNegativesVerified &&
-    isConclusionsVerified &&
+    isReviewVerified &&
     isReviewScoreVerified &&
     isThumbnailVerified &&
     isOriginalImagesVerified &&

--- a/src/shared/ui/multiple-text-form-input.tsx
+++ b/src/shared/ui/multiple-text-form-input.tsx
@@ -1,4 +1,4 @@
-import FormInput from './form-input';
+import FormTextArea from './form-textarea';
 import { MultipleFormValue } from './types';
 
 interface Props {
@@ -25,7 +25,7 @@ export default function MultipleTextFormInput({
       <label htmlFor={name}>{mainLabel}</label>
       {values.map((value, index) => (
         <span key={value.id} className="flex flex-row gap-2">
-          <FormInput
+          <FormTextArea
             type="text"
             id={name}
             name={name}


### PR DESCRIPTION
- Changed ReviewForm's validation into requiring at least 1 items among expectations, first-impressions, positives, negatives, and conclusions.
- Make expectations, first-impressions, positives, negatives, and conclusions show each content only if it has items.
- Expanded text inputs for expectations, first-impressions, positives, negatives, and conclusions.