### PR TITLE
fix: use label-for, checkbox, sibling-selector to show sidebar without blinking arcade-record link-tree

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import NavLink from '^/src/shared/ui/nav-link';
 import AlternativeHeader from '^/src/widgets/menu/alternative-header';
 import AuthLink from '^/src/widgets/menu/auth-link';
 
+import Sidebar from '^/src/features/sidebar';
 import { IS_PRODUCTION } from '^/src/shared/lib/is-production';
 import './globals.css';
 
@@ -66,6 +67,7 @@ export default function RootLayout({ children }: Readonly<Props>) {
         </header>
         {children}
         <AlternativeHeader />
+        <Sidebar />
         <Modal />
       </body>
     </html>

--- a/src/features/sidebar/caller.tsx
+++ b/src/features/sidebar/caller.tsx
@@ -1,29 +1,18 @@
-'use client';
-
 import Image from 'next/image';
 
 import StackSvgRepoComSvg from '^/public/icons/stack-svgrepo-com.svg';
-import { useModalStore } from '^/src/shared/modal/store';
-import { ModalType } from '^/src/shared/modal/types';
 
 export default function SidebarCaller() {
-  const setModal = useModalStore((state) => state.setModal);
-
   return (
-    <button
-      type="button"
+    <label
+      htmlFor="sidebar-open-checker"
       className="w-12 h-12 p-2 cursor-pointer"
-      onClick={() => {
-        setModal({
-          type: ModalType.SIDEBAR,
-        });
-      }}
     >
       <Image
         src={StackSvgRepoComSvg}
         className="w-full h-full fill-white"
         alt="사이드바 열기"
       />
-    </button>
+    </label>
   );
 }

--- a/src/features/sidebar/index.tsx
+++ b/src/features/sidebar/index.tsx
@@ -3,15 +3,12 @@ import Image from 'next/image';
 import CloseSvgRepoComSvg from '^/public/icons/close-svgrepo-com.svg';
 
 import SidebarLinkTree from './link-tree';
+import SidebarOpenChecker from './open-checker';
 
 export default function Sidebar() {
   return (
     <>
-      <input
-        type="checkbox"
-        id="sidebar-open-checker"
-        className="hidden [&_+_#sidebar-overlay]:hidden checked:[&_+_#sidebar-overlay]:block"
-      />
+      <SidebarOpenChecker />
       <div
         id="sidebar-overlay"
         className="fixed left-0 top-0 w-screen h-dvh bg-[rgba(0,0,0,0.4)] z-50 touch-none"

--- a/src/features/sidebar/index.tsx
+++ b/src/features/sidebar/index.tsx
@@ -1,13 +1,40 @@
+import Image from 'next/image';
+
+import CloseSvgRepoComSvg from '^/public/icons/close-svgrepo-com.svg';
+
 import SidebarLinkTree from './link-tree';
 
 export default function Sidebar() {
   return (
-    <div className="w-full h-full bg-primary text-white max-w-[40rem] grid grid-rows-[4rem_1fr_4rem]">
-      <div />
-      <SidebarLinkTree />
-      <div className="w-full h-full flex justify-center items-center">
-        YSO as kuman514
+    <>
+      <input
+        type="checkbox"
+        id="sidebar-open-checker"
+        className="hidden [&_+_#sidebar-overlay]:hidden checked:[&_+_#sidebar-overlay]:block"
+      />
+      <div
+        id="sidebar-overlay"
+        className="fixed left-0 top-0 w-screen h-dvh bg-[rgba(0,0,0,0.4)] z-50 touch-none"
+      >
+        <div className="w-full h-full bg-primary text-white max-w-[40rem] grid grid-rows-[4rem_1fr_4rem]">
+          <div className="w-full flex flex-row justify-start items-center px-2">
+            <label
+              htmlFor="sidebar-open-checker"
+              className="w-12 h-12 p-2 cursor-pointer"
+            >
+              <Image
+                src={CloseSvgRepoComSvg}
+                className="w-full h-full fill-white"
+                alt="사이드바 닫기"
+              />
+            </label>
+          </div>
+          <SidebarLinkTree />
+          <div className="w-full h-full flex justify-center items-center">
+            YSO as kuman514
+          </div>
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/features/sidebar/link-tree.tsx
+++ b/src/features/sidebar/link-tree.tsx
@@ -2,16 +2,12 @@
 
 import { useEffect, useState } from 'react';
 
-import { useModalStore } from '^/src/shared/modal/store';
-import { ModalType } from '^/src/shared/modal/types';
 import LinkTree from '^/src/shared/ui/link-tree';
 import { LinkTreeNode } from '^/src/shared/ui/types';
 
 import { getArcadeRecordTypeCount } from './data';
 
 export default function SidebarLinkTree() {
-  const setModal = useModalStore((state) => state.setModal);
-
   const [arcadeRecordTypeCount, setArcadeRecordTypeCount] = useState<
     LinkTreeNode[]
   >([]);
@@ -56,9 +52,12 @@ export default function SidebarLinkTree() {
           event.target instanceof HTMLAnchorElement &&
           event.target.nodeName === 'A'
         ) {
-          setModal({
-            type: ModalType.OFF,
-          });
+          const sidebarOpenChecker = document.querySelector(
+            'input#sidebar-open-checker'
+          );
+          if (sidebarOpenChecker instanceof HTMLInputElement) {
+            sidebarOpenChecker.checked = false;
+          }
         }
       }}
     >

--- a/src/features/sidebar/link-tree.tsx
+++ b/src/features/sidebar/link-tree.tsx
@@ -55,8 +55,11 @@ export default function SidebarLinkTree() {
           const sidebarOpenChecker = document.querySelector(
             'input#sidebar-open-checker'
           );
-          if (sidebarOpenChecker instanceof HTMLInputElement) {
-            sidebarOpenChecker.checked = false;
+          if (
+            sidebarOpenChecker instanceof HTMLInputElement &&
+            sidebarOpenChecker.checked
+          ) {
+            sidebarOpenChecker.click();
           }
         }
       }}

--- a/src/features/sidebar/open-checker.tsx
+++ b/src/features/sidebar/open-checker.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+export default function SidebarOpenChecker() {
+  return (
+    <input
+      type="checkbox"
+      id="sidebar-open-checker"
+      className="hidden [&_+_#sidebar-overlay]:hidden checked:[&_+_#sidebar-overlay]:block"
+      onChange={(event) => {
+        console.log(event.currentTarget.checked);
+        document.body.style.overflowY = event.currentTarget.checked
+          ? 'hidden'
+          : 'auto';
+      }}
+    />
+  );
+}

--- a/src/shared/modal/index.tsx
+++ b/src/shared/modal/index.tsx
@@ -5,7 +5,6 @@ import { useEffect } from 'react';
 
 import CloseSvgRepoComSvg from '^/public/icons/close-svgrepo-com.svg';
 import ImageViewer from '^/src/features/image-viewer';
-import Sidebar from '^/src/features/sidebar';
 
 import { useModalStore } from './store';
 import { ModalType } from './types';
@@ -27,8 +26,6 @@ export default function Modal() {
     switch (type) {
       case ModalType.IMAGE_VIEWER:
         return <ImageViewer />;
-      case ModalType.SIDEBAR:
-        return <Sidebar />;
       default:
         return null;
     }

--- a/src/shared/modal/types.ts
+++ b/src/shared/modal/types.ts
@@ -1,7 +1,6 @@
 export enum ModalType {
   OFF = 'off',
   IMAGE_VIEWER = 'image-viewer',
-  SIDEBAR = 'sidebar',
 }
 
 export interface OffModalState {
@@ -13,14 +12,7 @@ export interface ImageViewerModalState {
   imageUrls: string[];
 }
 
-export interface SidebarModalState {
-  type: ModalType.SIDEBAR;
-}
-
-export type ModalState =
-  | OffModalState
-  | ImageViewerModalState
-  | SidebarModalState;
+export type ModalState = OffModalState | ImageViewerModalState;
 
 export interface ModalActions {
   setModal: (newModalState: ModalState) => void;


### PR DESCRIPTION
- Changed `Sidebar` from using Zustand store to using `label`'s `htmlFor`, checkbox `input`, and sibling selector styling.
  - This pull request will resolve `SidebarLinkTree`'s arcade record part loading every time opening up `Sidebar`.