### PR TITLE
fix: revalidate only necessary routes on create/modify/delete posts

### DIFF
--- a/app/api/records/[arcadeRecordId]/route.ts
+++ b/app/api/records/[arcadeRecordId]/route.ts
@@ -120,7 +120,8 @@ export async function PUT(
       ],
     });
 
-    revalidatePath('/', 'layout');
+    revalidatePath('/', 'page');
+    revalidatePath('/records', 'layout');
     return NextResponse.json({ result: 'success' }, { status: 200 });
   } catch {
     return NextResponse.json(

--- a/app/api/records/route.ts
+++ b/app/api/records/route.ts
@@ -107,7 +107,8 @@ export async function POST(request: Request) {
       },
     });
 
-    revalidatePath('/', 'layout');
+    revalidatePath('/', 'page');
+    revalidatePath('/records', 'layout');
     return NextResponse.json({ result: 'success' }, { status: 201 });
   } catch {
     return NextResponse.json(

--- a/app/api/reviews/[reviewId]/route.ts
+++ b/app/api/reviews/[reviewId]/route.ts
@@ -122,7 +122,8 @@ export async function PUT(
       ],
     });
 
-    revalidatePath('/', 'layout');
+    revalidatePath('/', 'page');
+    revalidatePath('/reviews', 'layout');
     return NextResponse.json({ result: 'success' }, { status: 200 });
   } catch {
     return NextResponse.json(

--- a/app/api/reviews/route.ts
+++ b/app/api/reviews/route.ts
@@ -109,7 +109,8 @@ export async function POST(request: Request) {
       },
     });
 
-    revalidatePath('/', 'layout');
+    revalidatePath('/', 'page');
+    revalidatePath('/reviews', 'layout');
     return NextResponse.json({ result: 'success' }, { status: 201 });
   } catch {
     return NextResponse.json(

--- a/src/features/arcade-record-article/delete-arcade-record-action.ts
+++ b/src/features/arcade-record-article/delete-arcade-record-action.ts
@@ -32,6 +32,7 @@ export async function deleteArcadeRecordAction(_: null, formData: FormData) {
     ],
   });
 
-  revalidatePath('/');
+  revalidatePath('/', 'page');
+  revalidatePath('/records', 'layout');
   redirect(`/records`);
 }

--- a/src/features/review-article/delete-review-action.ts
+++ b/src/features/review-article/delete-review-action.ts
@@ -21,6 +21,7 @@ export async function deleteReviewAction(_: null, formData: FormData) {
 
   await deleteReviewPost(reviewId!);
 
-  revalidatePath('/');
+  revalidatePath('/', 'page');
+  revalidatePath('/reviews', 'layout');
   redirect(`/reviews`);
 }


### PR DESCRIPTION
- Made app revalidate caches for necessary routes on create/modify/delete posts.