### PR TITLE
fix: stop showing memo for arcade-record-post-list-items

### DIFF
--- a/app/records/[arcadeId]/page.tsx
+++ b/app/records/[arcadeId]/page.tsx
@@ -24,7 +24,7 @@ export default async function RecordListByTypeIdPage({ params }: Props) {
   const data = await getArcadeRecordPostListWithArcadeId(arcadeId);
   const postListItems: PostListItemProps[] = data.map((datum) => ({
     title: datum.title,
-    memo: datum.note ?? '메모 없음',
+    memo: datum.note ?? '',
     dateToDisplay: datum.achievedAt,
     tags: datum.tags,
     isHaveYouTube: Boolean(datum.youTubeId),

--- a/app/records/page.tsx
+++ b/app/records/page.tsx
@@ -10,7 +10,7 @@ export default async function RecordListPage() {
 
   const postListItems: PostListItemProps[] = data.map((datum) => ({
     title: datum.title,
-    memo: datum.note ?? '메모 없음',
+    memo: datum.note ?? '',
     dateToDisplay: datum.achievedAt,
     tags: datum.tags,
     isHaveYouTube: Boolean(datum.youTubeId),

--- a/src/entities/post-list-item/index.tsx
+++ b/src/entities/post-list-item/index.tsx
@@ -26,6 +26,9 @@ export default function PostListItem({
     );
   })();
 
+  const renderMemo =
+    memo.length > 0 ? <span className="text-white">{memo}</span> : null;
+
   const renderTags =
     tags.length > 0 ? (
       <div className="flex flex-row flex-wrap gap-1">
@@ -66,7 +69,7 @@ export default function PostListItem({
               <span className="text-xl text-white font-bold drop-shadow-[0_0_12px_rgba(32,32,32,1)] sm:text-2xl">
                 {title}
               </span>
-              <span className="text-white">{memo}</span>
+              {renderMemo}
             </div>
             {renderTags}
           </div>

--- a/src/widgets/recent-post-widget/arcade-records.tsx
+++ b/src/widgets/recent-post-widget/arcade-records.tsx
@@ -12,7 +12,7 @@ export default async function RecentArcadeRecordPostsWidget() {
     })
   ).map((datum) => ({
     title: datum.title,
-    memo: datum.note ?? '메모 없음',
+    memo: datum.note ?? '',
     dateToDisplay: datum.achievedAt,
     tags: datum.tags,
     isHaveYouTube: Boolean(datum.youTubeId),


### PR DESCRIPTION
- Stopped showing fallback string like "메모 없음" in an `ArcadeRecordPost` list item when the `ArcadeRecordPost` has no note.