### PR TITLE
fix: select only necessary columns for arcade-record/review post list items

### DIFF
--- a/src/features/arcade-record-article/arcade-record-post-list/data.ts
+++ b/src/features/arcade-record-article/arcade-record-post-list/data.ts
@@ -7,7 +7,8 @@ import { convertArcadeRecordPostDBColumnToArcadeRecordPost } from './util';
 
 export async function getArcadeRecordPostList(range?: SelectRange) {
   const result = await selectData<ArcadeRecordPostDBColumn[]>({
-    select: '*, arcade_info (*), methods (*)',
+    select:
+      'arcade_record_id, title, note, achieved_at, tags, youtube_id, thumbnail_url, arcade_info (*), methods (*)',
     from: 'records',
     where: [],
     order: [
@@ -26,7 +27,8 @@ export async function getArcadeRecordPostListWithArcadeId(
   arcadeId: ArcadeInfo['arcadeId']
 ) {
   const result = await selectData<ArcadeRecordPostDBColumn[]>({
-    select: '*, arcade_info (*), methods (*)',
+    select:
+      'arcade_record_id, title, note, achieved_at, tags, youtube_id, thumbnail_url, arcade_info (*), methods (*)',
     from: 'records',
     where: [
       {

--- a/src/features/review-article/review-post-list/data.ts
+++ b/src/features/review-article/review-post-list/data.ts
@@ -6,7 +6,8 @@ import { convertReviewPostDBColumnToReviewPost } from './util';
 
 export async function getReviewPostList(range?: SelectRange) {
   const result = await selectData<ReviewPostDBColumn[]>({
-    select: '*',
+    select:
+      'review_id, title, subject_name, subject_type, created_at, tags, youtube_id, thumbnail_url',
     from: 'reviews',
     where: [],
     order: [


### PR DESCRIPTION
- Made `getArcadeRecordPostList`, `getArcadeRecordPostListWithArcadeId`, and `getReviewPostList` select only nevessary columns to improve loading speed.