### PR TITLE
fix: stop optimizing svgs & images in image-zoom-controller to reduce vercel image optimization transform

### DIFF
--- a/src/entities/post-list-item/index.tsx
+++ b/src/entities/post-list-item/index.tsx
@@ -45,7 +45,7 @@ export default function PostListItem({
 
   const renderYouTubeMark = isHaveYouTube ? (
     <div className="absolute left-0 top-0 w-full h-full flex flex-col justify-start items-end z-1 px-4 py-3">
-      <Image src={YouTubeMarkSvg} alt="YouTube 영상 포함" />
+      <Image unoptimized src={YouTubeMarkSvg} alt="YouTube 영상 포함" />
     </div>
   ) : null;
 

--- a/src/features/arcade-record-article/record-form.tsx
+++ b/src/features/arcade-record-article/record-form.tsx
@@ -508,6 +508,7 @@ export default function RecordForm({
               alt="기존 썸네일 이미지"
               fill
               sizes="10rem"
+              unoptimized
             />
           </div>
           <input

--- a/src/features/image-viewer/index.tsx
+++ b/src/features/image-viewer/index.tsx
@@ -34,6 +34,7 @@ export default function ImageViewer() {
             src={ArrowSquareLeftSvgRepoComSvg}
             className="w-full h-full fill-white"
             alt="이전 이미지"
+            unoptimized
           />
         </button>
         <button
@@ -47,6 +48,7 @@ export default function ImageViewer() {
             src={ArrowSquareRightSvgRepoComSvg}
             className="w-full h-full fill-white"
             alt="다음 이미지"
+            unoptimized
           />
         </button>
       </div>

--- a/src/features/review-article/index.tsx
+++ b/src/features/review-article/index.tsx
@@ -92,6 +92,7 @@ export default function ReviewArticle({ post }: Props) {
                 key={score}
                 src={FilledStarSvgRepoComSvg}
                 alt={`${score}점`}
+                unoptimized
               />
             ) : (
               <Image
@@ -99,6 +100,7 @@ export default function ReviewArticle({ post }: Props) {
                 key={score}
                 src={StarSvgRepoComSvg}
                 alt={`${score}점`}
+                unoptimized
               />
             )
           )}

--- a/src/features/review-article/review-form.tsx
+++ b/src/features/review-article/review-form.tsx
@@ -463,9 +463,13 @@ export default function ReviewForm({ post }: Props) {
               className="w-1/6 dark:invert cursor-pointer"
             >
               {reviewScore >= score ? (
-                <Image src={FilledStarSvgRepoComSvg} alt={`${score}점`} />
+                <Image
+                  src={FilledStarSvgRepoComSvg}
+                  unoptimized
+                  alt={`${score}점`}
+                />
               ) : (
-                <Image src={StarSvgRepoComSvg} alt={`${score}점`} />
+                <Image src={StarSvgRepoComSvg} unoptimized alt={`${score}점`} />
               )}
             </button>
           ))}

--- a/src/features/sidebar/caller.tsx
+++ b/src/features/sidebar/caller.tsx
@@ -12,6 +12,7 @@ export default function SidebarCaller() {
         src={StackSvgRepoComSvg}
         className="w-full h-full fill-white"
         alt="사이드바 열기"
+        unoptimized
       />
     </label>
   );

--- a/src/features/sidebar/index.tsx
+++ b/src/features/sidebar/index.tsx
@@ -23,6 +23,7 @@ export default function Sidebar() {
                 src={CloseSvgRepoComSvg}
                 className="w-full h-full fill-white"
                 alt="사이드바 닫기"
+                unoptimized
               />
             </label>
           </div>

--- a/src/shared/image-picker/image-list/element.tsx
+++ b/src/shared/image-picker/image-list/element.tsx
@@ -50,7 +50,13 @@ export default function ImageListElement({
     >
       <div className="w-40 h-40 relative">
         {imageUrl ? (
-          <Image src={imageUrl} alt="유저 선택 이미지" fill sizes="10rem" />
+          <Image
+            src={imageUrl}
+            alt="유저 선택 이미지"
+            fill
+            sizes="10rem"
+            unoptimized
+          />
         ) : (
           <div className="w-full h-full" />
         )}

--- a/src/shared/image-zoom-controller/index.tsx
+++ b/src/shared/image-zoom-controller/index.tsx
@@ -115,6 +115,7 @@ export default function ImageZoomController({ imageUrl, alt }: Props) {
         alt={alt}
         fill
         sizes="100vw"
+        unoptimized
       />
     </div>
   );

--- a/src/shared/modal/index.tsx
+++ b/src/shared/modal/index.tsx
@@ -44,6 +44,7 @@ export default function Modal() {
           src={CloseSvgRepoComSvg}
           className="w-full h-full fill-white"
           alt="모달 닫기"
+          unoptimized
         />
       </button>
     </div>

--- a/src/shared/share/copy-link.tsx
+++ b/src/shared/share/copy-link.tsx
@@ -20,6 +20,7 @@ export function CopyLinkButton() {
         src={LinkSvg}
         alt="링크 복사하기"
         className="w-6 h-6 color-primary"
+        unoptimized
       />
     </button>
   );

--- a/src/shared/share/share-to-twitter.tsx
+++ b/src/shared/share/share-to-twitter.tsx
@@ -35,6 +35,7 @@ export function ShareToTwitterButton({ postTitle }: Props) {
         src={TwitterSvg}
         alt="Twitter로 공유하기"
         className="w-6 h-6 color-primary"
+        unoptimized
       />
     </button>
   );


### PR DESCRIPTION
- Stopped optimizing SVG images [since it does not have benefit](https://nextjs.org/docs/app/api-reference/components/image#unoptimized).
- Stopped optimizing images from `ImageZoomController` to reduce Vercel Image Optimization Transform calls.