### PR TITLE
fix: require evaluation's length to be more than 0 for record-form

### DIFF
--- a/src/features/arcade-record-article/record-form.tsx
+++ b/src/features/arcade-record-article/record-form.tsx
@@ -79,14 +79,16 @@ export default function RecordForm({
   const isTitleVerified = title.length > 0;
   const isArcadeIdVerified = arcadeId.length > 0;
   const isMethodIdVerified = methodId.length > 0;
-  const isEvaluationVerified = (() => {
-    try {
-      parseEvaluation(evaluation);
-      return true;
-    } catch {
-      return false;
-    }
-  })();
+  const isEvaluationVerified =
+    evaluation.length > 0 &&
+    (() => {
+      try {
+        parseEvaluation(evaluation);
+        return true;
+      } catch {
+        return false;
+      }
+    })();
   const isStageVerified = stage.length > 0;
   const isCommentVerified = comment.length > 0;
   const isThumbnailVerified = !!post?.thumbnailUrl || !!localThumbnail;


### PR DESCRIPTION
- Make evaluation need to have length more than 0, of course requiring to fit its format.