### PR TITLE
fix: show marker for unordered list items

### DIFF
--- a/src/shared/unordered-list/index.tsx
+++ b/src/shared/unordered-list/index.tsx
@@ -5,5 +5,5 @@ interface Props {
 }
 
 export default function UnorderedList({ children }: Props) {
-  return <ul className="ps-8 [&_li]:marker:content-['•_']">{children}</ul>;
+  return <ul className="ps-8 list-disc">{children}</ul>;
 }


### PR DESCRIPTION
- Added disc marker for `UnorderedList`'s list items.