### PR TITLE
fix: set items-per-page to 5 to reduce shown items at once

### DIFF
--- a/src/entities/constants/pagenation.ts
+++ b/src/entities/constants/pagenation.ts
@@ -1,1 +1,1 @@
-export const ITEMS_PER_PAGE = 10;
+export const ITEMS_PER_PAGE = 5;


### PR DESCRIPTION
- Set `ITEMS_PER_PAGE` to 5 to reduce showing items at once.
  - Initially 10, and 5 per extension.