### PR TITLE
refactor: use turbopack instead of experimental.turbo for svgr turbo config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,12 +6,12 @@ const nextConfig: NextConfig = {
     serverActions: {
       bodySizeLimit: '50mb',
     },
-    turbo: {
-      rules: {
-        '*.svg': {
-          loaders: ['@svgr/webpack'],
-          as: '*.js',
-        },
+  },
+  turbopack: {
+    rules: {
+      '*.svg': {
+        loaders: ['@svgr/webpack'],
+        as: '*.js',
       },
     },
   },


### PR DESCRIPTION
- Moved svgr/webpack config to `turbopack.rules`. (was from `experimental.turbo`)