### PR TITLE
fix: set created-at/modified-at with iso-string on create/modify gallery to be ordered by created-at properly

### DIFF
--- a/app/api/gallery/[galleryId]/route.ts
+++ b/app/api/gallery/[galleryId]/route.ts
@@ -54,10 +54,7 @@ export async function PUT(
     }
   }
 
-  const createdDate = new Date();
-  const formattedDate = `${createdDate.getFullYear()}-${String(
-    createdDate.getMonth() + 1
-  ).padStart(2, '0')}-${String(createdDate.getDate()).padStart(2, '0')}`;
+  const modifiedDate = new Date().toISOString();
 
   try {
     await updateData<Partial<GalleryPostDBInput>>({
@@ -68,8 +65,7 @@ export async function PUT(
         gallery_theme_id: galleryThemeId,
         thumbnail_url: thumbnailUrl ?? presentThumbnailUrl,
         image_url: originalImageUrl ?? presentImageUrl,
-        created_at: formattedDate,
-        modified_at: formattedDate,
+        modified_at: modifiedDate,
       },
       where: [
         {

--- a/app/api/gallery/route.ts
+++ b/app/api/gallery/route.ts
@@ -46,10 +46,7 @@ export async function POST(request: Request) {
     }
   }
 
-  const createdDate = new Date();
-  const formattedDate = `${createdDate.getFullYear()}-${String(
-    createdDate.getMonth() + 1
-  ).padStart(2, '0')}-${String(createdDate.getDate()).padStart(2, '0')}`;
+  const createdDate = new Date().toISOString();
 
   try {
     await insertData<Omit<GalleryPostDBInput, 'id'>>({
@@ -60,8 +57,8 @@ export async function POST(request: Request) {
         gallery_theme_id: galleryThemeId,
         thumbnail_url: thumbnailUrl,
         image_url: originalImageUrl,
-        created_at: formattedDate,
-        modified_at: formattedDate,
+        created_at: createdDate,
+        modified_at: createdDate,
       },
     });
 


### PR DESCRIPTION
- Made `createdAt` and `modifiedAt` in creating/modifying gallery post use `.toISOString()`.
  - This will make getting gallery list ordered by `createdAt` properly.