### PR TITLE
fix: stop showing remaining image when changing image in image-viewer

### DIFF
--- a/src/features/image-viewer/index.tsx
+++ b/src/features/image-viewer/index.tsx
@@ -54,6 +54,7 @@ export default function ImageViewer() {
   return (
     <>
       <ImageZoomController
+        key={new Date().getTime()}
         imageUrl={imageUrls[currentShowIndex]}
         alt="아케이드 기록 관련 사진"
       />


### PR DESCRIPTION
- Prevented showing a previous image remaining even after changing an image URL in `ImageViewer`.