### PR TITLE
improvement: indicate the number of multiple images in figcaption of thumbnail in records/reviews

### DIFF
--- a/src/features/arcade-record-article/arcade-record-thumbnail/index.tsx
+++ b/src/features/arcade-record-article/arcade-record-thumbnail/index.tsx
@@ -11,6 +11,9 @@ export default function ArcadeRecordThumbnail({
   thumbnailUrl,
   originalImageUrls,
 }: Props) {
+  const additionalFigCaptionText =
+    originalImageUrls.length > 1 ? `${originalImageUrls.length}개 ` : null;
+
   return (
     <figure className="flex flex-col justify-center items-center gap-2">
       <div className="relative w-full sm:w-80 h-80 bg-black">
@@ -26,7 +29,7 @@ export default function ArcadeRecordThumbnail({
         />
       </div>
       <figcaption className="text-xs">
-        [ 썸네일을 클릭하여 이미지 보기 ]
+        [ 썸네일을 클릭하여 이미지 {additionalFigCaptionText}보기 ]
       </figcaption>
     </figure>
   );

--- a/src/features/review-article/review-thumbnail/index.tsx
+++ b/src/features/review-article/review-thumbnail/index.tsx
@@ -11,6 +11,9 @@ export default function ReviewThumbnail({
   thumbnailUrl,
   originalImageUrls,
 }: Props) {
+  const additionalFigCaptionText =
+    originalImageUrls.length > 1 ? `${originalImageUrls.length}개 ` : null;
+
   return (
     <figure className="w-full flex flex-col justify-center items-center gap-2">
       <div className="relative w-full h-80 bg-black">
@@ -24,7 +27,7 @@ export default function ReviewThumbnail({
         <ReviewThumbnailInteractivity originalImageUrls={originalImageUrls} />
       </div>
       <figcaption className="text-xs">
-        [ 썸네일을 클릭하여 이미지 보기 ]
+        [ 썸네일을 클릭하여 이미지 {additionalFigCaptionText}보기 ]
       </figcaption>
     </figure>
   );


### PR DESCRIPTION
- Added the number of `originalImageUrls` in `ArcadeRecordThumbnail` and `ReviewThumbnail` to indicate how many original images the record/review contains.