### PR TITLE
refactor: move modal component to widgets since it contains feature-level modules

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,10 +6,10 @@ import Contact from '^/src/features/contact';
 import Sidebar from '^/src/features/sidebar';
 import SidebarCaller from '^/src/features/sidebar/caller';
 import { IS_PRODUCTION } from '^/src/shared/lib/is-production';
-import Modal from '^/src/shared/modal';
 import NavLink from '^/src/shared/ui/nav-link';
 import AlternativeHeader from '^/src/widgets/menu/alternative-header';
 import AuthLink from '^/src/widgets/menu/auth-link';
+import Modal from '^/src/widgets/modal';
 import { ToastContainer } from 'react-toastify';
 
 import './globals.css';

--- a/src/features/arcade-record-article/delete-form.tsx
+++ b/src/features/arcade-record-article/delete-form.tsx
@@ -3,8 +3,8 @@
 import { useActionState } from 'react';
 
 import { ArcadeRecordPost } from '^/src/entities/types/post';
-
 import { useLoadingBlockModal } from '^/src/shared/modal/loading-block';
+
 import { deleteArcadeRecordAction } from './delete-arcade-record-action';
 
 interface Props {

--- a/src/features/auth/sign-in-form.tsx
+++ b/src/features/auth/sign-in-form.tsx
@@ -6,8 +6,8 @@ import FormInput from '^/src/shared/ui/form-input';
 
 import { checkIsEmailValid } from '^/src/shared/lib/email';
 import { checkIsPasswordValid } from '^/src/shared/lib/password';
-
 import { useLoadingBlockModal } from '^/src/shared/modal/loading-block';
+
 import { AuthActionState } from './action-state';
 import { signInAction } from './sign-in-action';
 

--- a/src/features/auth/sign-out-form.tsx
+++ b/src/features/auth/sign-out-form.tsx
@@ -3,6 +3,7 @@
 import { useActionState } from 'react';
 
 import { useLoadingBlockModal } from '^/src/shared/modal/loading-block';
+
 import { signOutAction } from './sign-out-action';
 
 export default function SignOutForm() {

--- a/src/features/gallery/delete-form.tsx
+++ b/src/features/gallery/delete-form.tsx
@@ -3,8 +3,8 @@
 import { useActionState } from 'react';
 
 import { GalleryPost } from '^/src/entities/types/post';
-
 import { useLoadingBlockModal } from '^/src/shared/modal/loading-block';
+
 import { deleteGalleryAction } from './delete-gallery-action';
 
 interface Props {

--- a/src/features/review-article/delete-form.tsx
+++ b/src/features/review-article/delete-form.tsx
@@ -3,8 +3,8 @@
 import { useActionState } from 'react';
 
 import { ReviewPost } from '^/src/entities/types/post';
-
 import { useLoadingBlockModal } from '^/src/shared/modal/loading-block';
+
 import { deleteReviewAction } from './delete-review-action';
 
 interface Props {

--- a/src/widgets/modal/index.tsx
+++ b/src/widgets/modal/index.tsx
@@ -5,9 +5,8 @@ import { useEffect } from 'react';
 import CloseSvgRepoComSvg from '^/public/icons/close-svgrepo-com.svg';
 import LoadingSvg from '^/public/icons/loading.svg';
 import ImageViewer from '^/src/features/image-viewer';
-
-import { useModalStore } from './store';
-import { ModalType } from './types';
+import { useModalStore } from '^/src/shared/modal/store';
+import { ModalType } from '^/src/shared/modal/types';
 
 export default function Modal() {
   const { type, setModal } = useModalStore();


### PR DESCRIPTION
- Moved `Modal` component since it has a feature level component `ImageViewer`.
  - We need the pull request to be merged to keep FSD rules.