### PR TITLE
fix: stop showing null for rank in arcade record post list item

### DIFF
--- a/src/features/arcade-record-article/arcade-record-post-list/util.ts
+++ b/src/features/arcade-record-article/arcade-record-post-list/util.ts
@@ -75,7 +75,9 @@ export function convertArcadeRecordPostToPostListItem({
 
   return {
     title: title,
-    memo: `${arcade.label} - ${stage} / ${evaluations}${rank && ` / ${rank}`}`,
+    memo: `${arcade.label} - ${stage} / ${evaluations}${
+      rank ? ` / ${rank}` : ''
+    }`,
     dateToDisplay: achievedAt,
     tags: tags,
     isHaveYouTube: Boolean(youTubeId),


### PR DESCRIPTION
- Prevent showing `null` for `ArcadeRecordPostListItem` when `rank` is `null`.