### PR TITLE
refactor: unify getting arcade record post list

### DIFF
--- a/app/records/[arcadeId]/page.tsx
+++ b/app/records/[arcadeId]/page.tsx
@@ -6,7 +6,7 @@ import { ITEMS_PER_PAGE } from '^/src/entities/constants/pagenation';
 import { PostListItemProps } from '^/src/entities/post-list-item/props';
 import { getArcadeInfo } from '^/src/features/arcade-info/data';
 import ArcadeRecordPostList from '^/src/features/arcade-record-article/arcade-record-post-list';
-import { getArcadeRecordPostListWithArcadeId } from '^/src/features/arcade-record-article/arcade-record-post-list/data';
+import { getArcadeRecordPostList } from '^/src/features/arcade-record-article/arcade-record-post-list/data';
 import { convertArcadeRecordPostToPostListItem } from '^/src/features/arcade-record-article/arcade-record-post-list/util';
 
 interface Props {
@@ -23,10 +23,13 @@ export default async function RecordListByTypeIdPage({ params }: Props) {
     notFound();
   }
 
-  const data = await getArcadeRecordPostListWithArcadeId(arcadeId, {
-    from: 0,
-    to: ITEMS_PER_PAGE - 1,
-  });
+  const data = await getArcadeRecordPostList(
+    {
+      from: 0,
+      to: ITEMS_PER_PAGE - 1,
+    },
+    arcadeId
+  );
   const postListItems: PostListItemProps[] = data.map(
     convertArcadeRecordPostToPostListItem
   );

--- a/src/features/arcade-record-article/arcade-record-post-list/data.ts
+++ b/src/features/arcade-record-article/arcade-record-post-list/data.ts
@@ -5,44 +5,23 @@ import { ConditionType, SelectRange } from '^/src/shared/supabase/types';
 
 import { convertArcadeRecordPostDBColumnToArcadeRecordPost } from './util';
 
-/**
- * @todo
- * Unify `getArcadeRecordPostList` and `getArcadeRecordPostListWithArcadeId`.
- */
-
-export async function getArcadeRecordPostList(range?: SelectRange) {
+export async function getArcadeRecordPostList(
+  range?: SelectRange,
+  arcadeId?: ArcadeInfo['arcadeId']
+) {
   const result = await selectData<ArcadeRecordPostDBColumn[]>({
     select:
       'arcade_record_id, stage, rank, title, evaluation, score, elapsed_time, achieved_at, tags, youtube_id, thumbnail_url, arcade_info (*), methods (*)',
     from: 'records',
-    where: [],
-    order: [
-      {
-        column: 'achieved_at',
-        isAscending: false,
-      },
-    ],
-    range,
-  });
-
-  return result.map(convertArcadeRecordPostDBColumnToArcadeRecordPost);
-}
-
-export async function getArcadeRecordPostListWithArcadeId(
-  arcadeId: ArcadeInfo['arcadeId'],
-  range?: SelectRange
-) {
-  const result = await selectData<ArcadeRecordPostDBColumn[]>({
-    select:
-      'arcade_record_id, title, note, achieved_at, tags, youtube_id, thumbnail_url, arcade_info (*), methods (*)',
-    from: 'records',
-    where: [
-      {
-        type: ConditionType.EQUAL,
-        column: 'arcade_id',
-        value: arcadeId,
-      },
-    ],
+    where: arcadeId
+      ? [
+          {
+            type: ConditionType.EQUAL,
+            column: 'arcade_id',
+            value: arcadeId,
+          },
+        ]
+      : [],
     order: [
       {
         column: 'achieved_at',


### PR DESCRIPTION
- Unified `getArcadeRecordPostList` and `getArcadeRecordPostListWithArcadeId` to prevent inconsistent attributes in getting an arcade record post list.