### PR TITLE
fix: handle images of arcade-records only from '/records/**/*'

### DIFF
--- a/app/api/records/[arcadeRecordId]/route.ts
+++ b/app/api/records/[arcadeRecordId]/route.ts
@@ -213,7 +213,7 @@ export async function PUT(
     revalidatePath('/', 'page');
     revalidatePath('/records', 'layout');
 
-    const imagePath = `${arcadeId}/${arcadeRecordId}`;
+    const imagePath = `records/${arcadeRecordId}`;
     const usedImages = originalImageUrls
       .concat(
         thumbnailUrl || presentThumbnailUrl

--- a/app/api/records/route.ts
+++ b/app/api/records/route.ts
@@ -202,7 +202,7 @@ export async function POST(request: Request) {
     revalidatePath('/', 'page');
     revalidatePath('/records', 'layout');
 
-    const imagePath = `${arcadeId}/${arcadeRecordId}`;
+    const imagePath = `records/${arcadeRecordId}`;
     const usedImages = originalImageUrls
       .concat([thumbnailUrl!])
       .map((image) => image.split('/').pop()!);

--- a/src/features/arcade-record-article/delete-arcade-record-action.ts
+++ b/src/features/arcade-record-article/delete-arcade-record-action.ts
@@ -3,8 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
-import { ArcadeRecordPostDBColumn } from '^/src/entities/types/post';
-import { deleteData, selectData } from '^/src/shared/supabase/database';
+import { deleteData } from '^/src/shared/supabase/database';
 import { removeUnusedImages } from '^/src/shared/supabase/image';
 import { createServerSideClient } from '^/src/shared/supabase/server';
 import { ConditionType } from '^/src/shared/supabase/types';
@@ -23,20 +22,6 @@ export async function deleteArcadeRecordAction(_: null, formData: FormData) {
     return null;
   }
 
-  const arcadeId = (
-    await selectData<Pick<ArcadeRecordPostDBColumn, 'arcade_id'>[]>({
-      select: 'arcade_id',
-      from: 'records',
-      where: [
-        {
-          type: ConditionType.EQUAL,
-          column: 'arcade_record_id',
-          value: arcadeRecordId,
-        },
-      ],
-    })
-  )[0].arcade_id;
-
   await deleteData({
     deleteFrom: 'records',
     where: [
@@ -51,7 +36,7 @@ export async function deleteArcadeRecordAction(_: null, formData: FormData) {
   revalidatePath('/', 'page');
   revalidatePath('/records', 'layout');
 
-  removeUnusedImages(`${arcadeId}/${arcadeRecordId}`, []);
+  removeUnusedImages(`records/${arcadeRecordId}`, []);
 
   redirect(`/records`);
 }

--- a/src/features/arcade-record-article/record-form.tsx
+++ b/src/features/arcade-record-article/record-form.tsx
@@ -166,7 +166,7 @@ export default function RecordForm({
     setIsLoading(true);
     setErrorMessage(null);
 
-    const path = `${arcadeId}/${arcadeRecordId}`;
+    const path = `records/${arcadeRecordId}`;
     const timestamp = new Date().toISOString();
 
     const thumbnailUrl = localThumbnail


### PR DESCRIPTION
- Made app upload further new images about arcade records to `/records/:arcadeRecordId`, since `arcadeId` in `/:arcadeId/:arcadeRecordId` (path where images about arcade records are saved) can be changed.