### PR TITLE
improvement: make stage, rank, tag in record-form follow arcade-info's options

### DIFF
--- a/app/api/records/[arcadeRecordId]/route.ts
+++ b/app/api/records/[arcadeRecordId]/route.ts
@@ -6,10 +6,10 @@ import { updateData } from '^/src/shared/supabase/database';
 import { removeUnusedImages } from '^/src/shared/supabase/image';
 import { createServerSideClient } from '^/src/shared/supabase/server';
 import { ConditionType } from '^/src/shared/supabase/types';
-import { parseEvaluation } from '^/src/shared/util/parse-evaluation';
-import { EvaluationCriterion } from '^/src/shared/util/types';
 import { generateKstDate } from '^/src/shared/util/generate-kst-date';
 import { parseDateToDatabaseString } from '^/src/shared/util/parse-date';
+import { parseEvaluation } from '^/src/shared/util/parse-evaluation';
+import { EvaluationCriterion } from '^/src/shared/util/types';
 
 export async function PUT(
   request: Request,
@@ -43,7 +43,7 @@ export async function PUT(
   const comment = formData.get('comment')?.toString();
   const note = formData.get('note')?.toString();
   const youTubeId = formData.get('youTubeId')?.toString();
-  const tags = formData.get('tags')?.toString();
+  const tags = formData.getAll('tags') as string[];
 
   const presentThumbnailUrl = formData.get('presentThumbnailUrl')?.toString();
   const thumbnailUrl = formData.get('thumbnailUrl')?.toString();
@@ -188,11 +188,7 @@ export async function PUT(
         stage: stage,
         rank,
         comment: comment,
-        tags:
-          tags
-            ?.split(',')
-            .map((tag) => tag.trim())
-            .filter((tag) => tag.length > 0) ?? [],
+        tags: tags,
         note,
         youtube_id: youTubeId,
         thumbnail_url: thumbnailUrl ?? presentThumbnailUrl,

--- a/app/api/records/route.ts
+++ b/app/api/records/route.ts
@@ -5,10 +5,10 @@ import { ArcadeRecordPostDBInput } from '^/src/entities/types/post';
 import { insertData } from '^/src/shared/supabase/database';
 import { removeUnusedImages } from '^/src/shared/supabase/image';
 import { createServerSideClient } from '^/src/shared/supabase/server';
-import { parseEvaluation } from '^/src/shared/util/parse-evaluation';
-import { EvaluationCriterion } from '^/src/shared/util/types';
 import { generateKstDate } from '^/src/shared/util/generate-kst-date';
 import { parseDateToDatabaseString } from '^/src/shared/util/parse-date';
+import { parseEvaluation } from '^/src/shared/util/parse-evaluation';
+import { EvaluationCriterion } from '^/src/shared/util/types';
 
 export async function POST(request: Request) {
   const supabase = await createServerSideClient();
@@ -38,7 +38,7 @@ export async function POST(request: Request) {
   const comment = formData.get('comment')?.toString();
   const note = formData.get('note')?.toString();
   const youTubeId = formData.get('youTubeId')?.toString();
-  const tags = formData.get('tags')?.toString();
+  const tags = formData.getAll('tags') as string[];
 
   const thumbnailUrl = formData.get('thumbnailUrl')?.toString();
   const originalImageUrls = formData.getAll('originalImageUrls') as string[];
@@ -183,11 +183,7 @@ export async function POST(request: Request) {
         stage: stage,
         rank,
         comment: comment,
-        tags:
-          tags
-            ?.split(',')
-            .map((tag) => tag.trim())
-            .filter((tag) => tag.length > 0) ?? [],
+        tags,
         note,
         youtube_id: youTubeId,
         thumbnail_url: thumbnailUrl,

--- a/src/features/arcade-record-article/record-form.tsx
+++ b/src/features/arcade-record-article/record-form.tsx
@@ -13,6 +13,7 @@ import { ArcadeInfo } from '^/src/entities/types/arcade-info';
 import { Method } from '^/src/entities/types/method';
 import { ArcadeRecordPost } from '^/src/entities/types/post';
 import { useLoadingBlockModal } from '^/src/shared/modal/loading-block';
+import { issueUuid } from '^/src/shared/route-handler-call/issue-uuid';
 import {
   FailedRouteHandlerCallResponse,
   RouteHandlerCallResponse,
@@ -24,7 +25,6 @@ import FormInput from '^/src/shared/ui/form-input';
 import FormTextArea from '^/src/shared/ui/form-textarea';
 import { parseEvaluation } from '^/src/shared/util/parse-evaluation';
 import { EvaluationCriterion } from '^/src/shared/util/types';
-import { issueUuid } from '^/src/shared/route-handler-call/issue-uuid';
 
 interface Props {
   post?: ArcadeRecordPost;
@@ -358,6 +358,39 @@ export default function RecordForm({
     [methodList]
   );
 
+  const renderStageSelectOptions = useMemo(
+    () =>
+      ['']
+        .concat(
+          arcadeInfoList.find((arcadeInfo) => arcadeInfo.arcadeId === arcadeId)
+            ?.availableStages ?? []
+        )
+        .map((availableStage) => (
+          <option
+            key={`stage-selection-${availableStage}`}
+            value={availableStage}
+          >
+            {availableStage === '' ? '선택하세요' : availableStage}
+          </option>
+        )),
+    [arcadeInfoList, arcadeId]
+  );
+
+  const renderRankSelectOptions = useMemo(
+    () =>
+      ['']
+        .concat(
+          arcadeInfoList.find((arcadeInfo) => arcadeInfo.arcadeId === arcadeId)
+            ?.availableRanks ?? []
+        )
+        .map((availableRank) => (
+          <option key={`rank-selection-${availableRank}`} value={availableRank}>
+            {availableRank === '' ? '선택하세요' : availableRank}
+          </option>
+        )),
+    [arcadeInfoList, arcadeId]
+  );
+
   return (
     <form
       className="w-full flex flex-row flex-wrap justify-between items-start gap-y-8"
@@ -426,6 +459,8 @@ export default function RecordForm({
           name="arcadeId"
           value={arcadeId}
           onChange={(event) => {
+            setStage('');
+            setRank('');
             setArcadeId(event.currentTarget.value);
           }}
         >
@@ -501,15 +536,16 @@ export default function RecordForm({
 
       <p className="w-12/25 flex flex-col gap-2">
         <label htmlFor="stage">최종 스테이지</label>
-        <FormInput
-          type="text"
+        <FormDropdown
           id="stage"
           name="stage"
           value={stage}
           onChange={(event) => {
             setStage(event.currentTarget.value);
           }}
-        />
+        >
+          {renderStageSelectOptions}
+        </FormDropdown>
         {!isStageVerified && (
           <span>어느 스테이지까지 도달하였는지 입력해주세요.</span>
         )}
@@ -517,15 +553,16 @@ export default function RecordForm({
 
       <p className="w-12/25 flex flex-col gap-2">
         <label htmlFor="rank">최종 등급</label>
-        <FormInput
-          type="text"
+        <FormDropdown
           id="rank"
           name="rank"
           value={rank}
           onChange={(event) => {
             setRank(event.currentTarget.value);
           }}
-        />
+        >
+          {renderRankSelectOptions}
+        </FormDropdown>
       </p>
 
       <p className="w-full flex flex-col gap-2">

--- a/src/features/arcade-record-article/record-form.tsx
+++ b/src/features/arcade-record-article/record-form.tsx
@@ -84,7 +84,7 @@ export default function RecordForm({
   const [stage, setStage] = useState<string>(post?.stage ?? '');
   const [rank, setRank] = useState<string>(post?.rank ?? '');
   const [comment, setComment] = useState<string>(post?.comment ?? '');
-  const [tags, setTags] = useState<string>(post?.tags.join(',') ?? '');
+  const [tags, setTags] = useState<string[]>(post?.tags ?? []);
   const [note, setNote] = useState<string>(post?.note ?? '');
   const [youTubeId, setYouTubeId] = useState<string>(post?.youTubeId ?? '');
 
@@ -278,7 +278,7 @@ export default function RecordForm({
     recordFormData.append('comment', comment);
     recordFormData.append('note', note);
     recordFormData.append('youTubeId', youTubeId);
-    recordFormData.append('tags', tags);
+    tags.forEach((tag) => recordFormData.append('tags', tag));
 
     if (post?.thumbnailUrl) {
       recordFormData.append('presentThumbnailUrl', post.thumbnailUrl);
@@ -391,6 +391,35 @@ export default function RecordForm({
     [arcadeInfoList, arcadeId]
   );
 
+  const renderTags = (
+    arcadeInfoList.find((arcadeInfo) => arcadeInfo.arcadeId === arcadeId)
+      ?.availableTags ?? []
+  ).map((availableTag) => (
+    <span key={`tag-check-${availableTag}`} className="flex flex-row gap-2">
+      <input
+        name="tags"
+        id={`tag-check-${availableTag}`}
+        value={availableTag}
+        type="checkbox"
+        checked={tags.includes(availableTag)}
+        onChange={(event) => {
+          if (event.currentTarget.checked) {
+            setTags(tags.concat([availableTag]));
+            return;
+          }
+          const targetIndex = tags.findIndex((tag) => tag === availableTag);
+          if (targetIndex === -1) {
+            return;
+          }
+          const newTags = Array.from(tags);
+          newTags.splice(targetIndex, 1);
+          setTags(newTags);
+        }}
+      />
+      <label htmlFor={`tag-check-${availableTag}`}>{availableTag}</label>
+    </span>
+  ));
+
   return (
     <form
       className="w-full flex flex-row flex-wrap justify-between items-start gap-y-8"
@@ -461,6 +490,7 @@ export default function RecordForm({
           onChange={(event) => {
             setStage('');
             setRank('');
+            setTags([]);
             setArcadeId(event.currentTarget.value);
           }}
         >
@@ -579,18 +609,10 @@ export default function RecordForm({
         {!isCommentVerified && <span>코멘터리를 입력해주세요.</span>}
       </p>
 
-      <p className="w-full flex flex-col gap-2">
+      <div className="w-full flex flex-col gap-2">
         <label>태그 (콤마로 구분)</label>
-        <FormInput
-          type="text"
-          id="tags"
-          name="tags"
-          value={tags}
-          onChange={(event) => {
-            setTags(event.currentTarget.value);
-          }}
-        />
-      </p>
+        <div className="w-full flex flex-row gap-2">{renderTags}</div>
+      </div>
 
       <p className="w-full flex flex-col gap-2">
         <label htmlFor="note">비고</label>


### PR DESCRIPTION
- Made `stage` and `rank` selectable by `availableStages` and `availableRanks` from `ArcadeInfo`.
- Made `tags` checkable by `availableTags` from `ArcadeInfo`.