### PR TITLE
hotfix: prevent drawers' unnecessary sliding on init

### DIFF
--- a/src/widgets/menu/menu-drawer.tsx
+++ b/src/widgets/menu/menu-drawer.tsx
@@ -22,6 +22,9 @@ export default function MenuDrawer() {
       />
       <div
         id="menu-drawer-content"
+        style={{
+          visibility: 'hidden',
+        }}
         onClick={(event) => {
           if (
             !(event.target instanceof HTMLElement) ||

--- a/src/widgets/menu/open-checker.tsx
+++ b/src/widgets/menu/open-checker.tsx
@@ -30,6 +30,10 @@ export default function MenuDrawerOpenChecker() {
       id="menu-drawer-open-checker"
       className="hidden [&+#menu-drawer-overlay]:hidden checked:[&+#menu-drawer-overlay]:block [&~#menu-drawer-content]:translate-x-[100%] checked:[&~#menu-drawer-content]:translate-x-[0%] [&~#menu-drawer-content]:animate-slide-left-to-right checked:[&~#menu-drawer-content]:animate-slide-right-to-left"
       onChange={(event) => {
+        const content = document.querySelector('#menu-drawer-content');
+        if (content && content instanceof HTMLElement) {
+          content.style.visibility = 'visible';
+        }
         document.body.style.overflowY = event.currentTarget.checked
           ? 'hidden'
           : 'auto';

--- a/src/widgets/side-drawer/index.tsx
+++ b/src/widgets/side-drawer/index.tsx
@@ -14,6 +14,9 @@ export default function SideDrawer() {
       ></div>
       <aside
         id="side-drawer-content"
+        style={{
+          visibility: 'hidden',
+        }}
         className="fixed left-0 top-0 w-full h-dvh z-51 bg-primary text-white max-w-72 grid grid-rows-[4rem_1fr]"
       >
         <div className="w-full h-full flex flex-row items-center">

--- a/src/widgets/side-drawer/index.tsx
+++ b/src/widgets/side-drawer/index.tsx
@@ -1,13 +1,13 @@
 import CloseSvgRepoComSvg from '^/public/icons/close-svgrepo-com.svg';
 import Sidebar from '^/src/features/sidebar';
 
-import SidebarOpenChecker from './open-checker';
+import SideDrawerOpenChecker from './open-checker';
 import TitleLink from './title-link';
 
 export default function SideDrawer() {
   return (
     <>
-      <SidebarOpenChecker />
+      <SideDrawerOpenChecker />
       <div
         id="side-drawer-overlay"
         className="fixed left-0 top-0 w-screen h-dvh bg-[rgba(0,0,0,0.4)] z-50 touch-none"

--- a/src/widgets/side-drawer/open-checker.tsx
+++ b/src/widgets/side-drawer/open-checker.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 
-export default function SidebarOpenChecker() {
+export default function SideDrawerOpenChecker() {
   const checkerRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {

--- a/src/widgets/side-drawer/open-checker.tsx
+++ b/src/widgets/side-drawer/open-checker.tsx
@@ -30,6 +30,10 @@ export default function SideDrawerOpenChecker() {
       id="side-drawer-open-checker"
       className="hidden [&+#side-drawer-overlay]:hidden checked:[&+#side-drawer-overlay]:block [&~#side-drawer-content]:translate-x-[-100%] checked:[&~#side-drawer-content]:translate-x-[0%] [&~#side-drawer-content]:animate-slide-right-to-left checked:[&~#side-drawer-content]:animate-slide-left-to-right"
       onChange={(event) => {
+        const content = document.querySelector('#side-drawer-content');
+        if (content && content instanceof HTMLElement) {
+          content.style.visibility = 'visible';
+        }
         document.body.style.overflowY = event.currentTarget.checked
           ? 'hidden'
           : 'auto';


### PR DESCRIPTION
- Stopped `SideDrawer` and `MenuDrawer` to slide on initial state.